### PR TITLE
peepdf-3: declare a fake class to prevent errors when the dependency is missing

### DIFF
--- a/processing/pdf/pdf_peepdf.py
+++ b/processing/pdf/pdf_peepdf.py
@@ -11,6 +11,11 @@ try:
     HAVE_PEEPDF = True
 except ImportError:
     HAVE_PEEPDF = False
+    class PDFCore:
+        # declare a fake class
+        # To prevent errors when peepdf is missing
+        PDFFile = PDFIndirectObject = PDFDictionary = None
+        
 
 try:
     from jsbeautifier import beautify


### PR DESCRIPTION
When peepdf-3 is not installed, the peepdf FAME module fails due to the type hints in functions definition.

Eg: `extract_attachments(self, pdf: PDFCore.PDFFile, obj: PDFCore.PDFIndirectObject, version: int) -> None:` triggers error `NameError: name 'PDFCore' is not defined`


This happens because type hints are not handled by the logic of `HAVE_*`. This is usually not a problem because type hints are not used in most of FAME codebase ( :smiling_face_with_tear: ).

I'm not sure what's the cleanest way to handle this issue (removing the type hints ? ). I declared a fake class to resolve it, let me know if you have a better idea.